### PR TITLE
add ability to hide gui and overlay on start

### DIFF
--- a/wc3rpgLoader2.ahk
+++ b/wc3rpgLoader2.ahk
@@ -120,6 +120,8 @@ Gui, Add, Text, y+0, Exit
 Gui, Add, Text, y+0, Disable All during chat (wc3 only)
 Gui, Add, Text, y+0, Disable Hotkeys' Native Functions
 Gui, Add, Text, y+0, Ex: Alt+q or space if assigned
+Gui, Add, Text, y+0, Hide GUI on start
+Gui, Add, Text, y+0, Hide Overlay on start
 Gui, Add, Text, y+0, % "Newest version:`t`t`t`t  " . GetNewVersionTag()
 Gui, Font, s8
 Gui, Add, Button, x300 y30 w70 h20 gGetSetKey vShowHideMain
@@ -128,7 +130,9 @@ Gui, Add, Button, y+0 w70 h20 gGetSetKey vPauseGame
 Gui, Add, Button, y+0 w70 h20 disabled, ESC
 Gui, Add, Button, y+0 w70 h20 disabled, Alt+ESC
 Gui, Add, Checkbox, y+5 gGetSetCheckBoxValue vDisableAll 
-Gui, Add, Checkbox, y+25 gGetSetCheckBoxValue vDisableAllNativeFunctions 
+Gui, Add, Checkbox, y+25 gGetSetCheckBoxValue vDisableAllNativeFunctions
+Gui, Add, Checkbox, y+5 gGetSetCheckBoxValue vHideGuiOnStart
+Gui, Add, Checkbox, y+5 gGetSetCheckBoxValue vHideOverlayOnStart
 ;-----------------------------------------Hero Editor-------------------------------------------------------
 Gui, 2: Color, DCDCDC
 Gui, 2: Add, Text, x10 y10, Hero:
@@ -163,6 +167,9 @@ GetSetSettings()
 GetSetQuickCast()
 
 ;Show Gui on Start
+GUIShow := GetGuiValue("1", "HideGuiOnStart")
+OverlayShow := GetGuiValue("1", "HideOverlayOnStart")
+
 Gosub, ShowHideMain
 Gosub, ShowHideOverlay
 return
@@ -603,6 +610,11 @@ initial()
         IniWrite, 1, %iniFile%, Loader, ConvertToggle
         IniWrite, 1, %iniFile%, Host, BotCommandToggle
         IniWrite, 1, %iniFile%, Host, GameNamePlusToggle
+    }
+    if(clientVersion < 4.0) ; 4.0 Add hide gui and overlay settings on start
+    {
+        IniWrite, 0, %iniFile%, Settings, HideGuiOnStart
+        IniWrite, 0, %iniFile%, Settings, HideOverlayOnStart
     }
     IniWrite, %version%, %iniFile%, Settings, Version ; update client version
 }

--- a/wc3rpgLoader2.ahk
+++ b/wc3rpgLoader2.ahk
@@ -12,7 +12,7 @@ SetWinDelay, -1
 SetBatchLines, -1
 SetControlDelay -1
 Thread, interrupt, 0
-global version := 4.0
+global version := 4.1
 global iniFile := "wc3rpgLoaderData.ini"
 global CameraExe := "Camera\publish\Camera.exe"
 global KeyWaiting := False
@@ -611,7 +611,7 @@ initial()
         IniWrite, 1, %iniFile%, Host, BotCommandToggle
         IniWrite, 1, %iniFile%, Host, GameNamePlusToggle
     }
-    if(clientVersion < 4.0) ; 4.0 Add hide gui and overlay settings on start
+    if(clientVersion < 4.1) ; 4.1 Add hide gui and overlay settings on start
     {
         IniWrite, 0, %iniFile%, Settings, HideGuiOnStart
         IniWrite, 0, %iniFile%, Settings, HideOverlayOnStart


### PR DESCRIPTION
Create new check boxes for new variables
New variables are then used to save the settings into the ini file (at a default of 0)
after the ini file is saved use them to update the initial global variables for GUIShow and OverlayShow

once user ticks/unticks, it updates the GUI

I am unsure about the number in `if(clientVersion < 4.0)`