### PR TITLE
Edit inventory hotkey toggles

### DIFF
--- a/wc3rpgLoader2.ahk
+++ b/wc3rpgLoader2.ahk
@@ -959,9 +959,13 @@ PauseGame:
         SendInput, {F10}{M}{F10}
 return
 
+
+
 ;Common
 #IfWinActive, Warcraft III ; set hotkey only work for wc3
-$~Enter::
+$~+Enter::      ; Shift Enter
+$~NumpadEnter:: ; numpad Enter
+$~Enter::       ; Regular Enter
     if(GetGuiValue("1", "DisableAll") && WC3Chating = False)
     {
         WC3Chating := True
@@ -975,7 +979,24 @@ $~Enter::
         ;GuiControl, 3: Text, ActiveQuickCall, % "Quick Call: " ((QuickCall) ? ("Enabled") : ("Disabled"))
         ;GuiControl, 3: Text, ActiveNoMouse  , % "No Mouse: " ((NoMouse) ? ("Enabled") : ("Disabled"))
     }
-    else if(WinActive("Warcraft III") && GetGuiValue("1", "DisableAll") && WC3Chating = True)
+    else if(GetGuiValue("1", "DisableAll") && WC3Chating = True)
+    {
+        WC3Chating := False
+        inventory := SettingsHistory[1]
+        QuickCast := SettingsHistory[2]
+        QuickCall := SettingsHistory[3]
+        NoMouse := SettingsHistory[4]
+        GuiControl, 3: Text, ActiveInventory, % "Inventory: " ((inventory) ? ("Enabled") : ("Disabled"))
+        GuiControl, 3: Text, ActiveQuickCast, % "Quick Cast: " ((QuickCast) ? ("Enabled") : ("Disabled"))
+        ;GuiControl, 3: Text, ActiveQuickCall, % "Quick Call: " ((QuickCall) ? ("Enabled") : ("Disabled"))
+        ;GuiControl, 3: Text, ActiveNoMouse  , % "No Mouse: " ((NoMouse) ? ("Enabled") : ("Disabled"))
+    }
+return
+
+; If chatting was canceled
+$~LButton:: ; Left Click - Might be problematic if user clicks in UI area instead of play area
+$~Esc::     ; Escape
+    if(GetGuiValue("1", "DisableAll") && WC3Chating = True)
     {
         WC3Chating := False
         inventory := SettingsHistory[1]

--- a/wc3rpgLoader2.ahk
+++ b/wc3rpgLoader2.ahk
@@ -959,7 +959,30 @@ PauseGame:
         SendInput, {F10}{M}{F10}
 return
 
+disableCastsOnChatting(){
+    WC3Chating := True
+    SettingsHistory := [inventory, QuickCast, QuickCall, NoMouse]
+    inventory := False
+    QuickCast := False
+    QuickCall := False
+    NoMouse := False
+    GuiControl, 3: Text, ActiveInventory, % "Inventory: " ((inventory) ? ("Enabled") : ("Disabled"))
+    GuiControl, 3: Text, ActiveQuickCast, % "Quick Cast: " ((QuickCast) ? ("Enabled") : ("Disabled"))
+    ;GuiControl, 3: Text, ActiveQuickCall, % "Quick Call: " ((QuickCall) ? ("Enabled") : ("Disabled"))
+    ;GuiControl, 3: Text, ActiveNoMouse  , % "No Mouse: " ((NoMouse) ? ("Enabled") : ("Disabled"))
+}
 
+enableCastsAfterChatting(){
+    WC3Chating := False
+    inventory := SettingsHistory[1]
+    QuickCast := SettingsHistory[2]
+    QuickCall := SettingsHistory[3]
+    NoMouse := SettingsHistory[4]
+    GuiControl, 3: Text, ActiveInventory, % "Inventory: " ((inventory) ? ("Enabled") : ("Disabled"))
+    GuiControl, 3: Text, ActiveQuickCast, % "Quick Cast: " ((QuickCast) ? ("Enabled") : ("Disabled"))
+    ;GuiControl, 3: Text, ActiveQuickCall, % "Quick Call: " ((QuickCall) ? ("Enabled") : ("Disabled"))
+    ;GuiControl, 3: Text, ActiveNoMouse  , % "No Mouse: " ((NoMouse) ? ("Enabled") : ("Disabled"))
+}
 
 ;Common
 #IfWinActive, Warcraft III ; set hotkey only work for wc3
@@ -968,28 +991,11 @@ $~NumpadEnter:: ; numpad Enter
 $~Enter::       ; Regular Enter
     if(GetGuiValue("1", "DisableAll") && WC3Chating = False)
     {
-        WC3Chating := True
-        SettingsHistory := [inventory, QuickCast, QuickCall, NoMouse]
-        inventory := False
-        QuickCast := False
-        QuickCall := False
-        NoMouse := False
-        GuiControl, 3: Text, ActiveInventory, % "Inventory: " ((inventory) ? ("Enabled") : ("Disabled"))
-        GuiControl, 3: Text, ActiveQuickCast, % "Quick Cast: " ((QuickCast) ? ("Enabled") : ("Disabled"))
-        ;GuiControl, 3: Text, ActiveQuickCall, % "Quick Call: " ((QuickCall) ? ("Enabled") : ("Disabled"))
-        ;GuiControl, 3: Text, ActiveNoMouse  , % "No Mouse: " ((NoMouse) ? ("Enabled") : ("Disabled"))
+        disableCastsOnChatting()
     }
     else if(GetGuiValue("1", "DisableAll") && WC3Chating = True)
     {
-        WC3Chating := False
-        inventory := SettingsHistory[1]
-        QuickCast := SettingsHistory[2]
-        QuickCall := SettingsHistory[3]
-        NoMouse := SettingsHistory[4]
-        GuiControl, 3: Text, ActiveInventory, % "Inventory: " ((inventory) ? ("Enabled") : ("Disabled"))
-        GuiControl, 3: Text, ActiveQuickCast, % "Quick Cast: " ((QuickCast) ? ("Enabled") : ("Disabled"))
-        ;GuiControl, 3: Text, ActiveQuickCall, % "Quick Call: " ((QuickCall) ? ("Enabled") : ("Disabled"))
-        ;GuiControl, 3: Text, ActiveNoMouse  , % "No Mouse: " ((NoMouse) ? ("Enabled") : ("Disabled"))
+        enableCastsAfterChatting()
     }
 return
 
@@ -998,15 +1004,7 @@ $~LButton:: ; Left Click - Might be problematic if user clicks in UI area instea
 $~Esc::     ; Escape
     if(GetGuiValue("1", "DisableAll") && WC3Chating = True)
     {
-        WC3Chating := False
-        inventory := SettingsHistory[1]
-        QuickCast := SettingsHistory[2]
-        QuickCall := SettingsHistory[3]
-        NoMouse := SettingsHistory[4]
-        GuiControl, 3: Text, ActiveInventory, % "Inventory: " ((inventory) ? ("Enabled") : ("Disabled"))
-        GuiControl, 3: Text, ActiveQuickCast, % "Quick Cast: " ((QuickCast) ? ("Enabled") : ("Disabled"))
-        ;GuiControl, 3: Text, ActiveQuickCall, % "Quick Call: " ((QuickCall) ? ("Enabled") : ("Disabled"))
-        ;GuiControl, 3: Text, ActiveNoMouse  , % "No Mouse: " ((NoMouse) ? ("Enabled") : ("Disabled"))
+        enableCastsAfterChatting()
     }
 return
 

--- a/wc3rpgLoader2.ahk
+++ b/wc3rpgLoader2.ahk
@@ -12,7 +12,7 @@ SetWinDelay, -1
 SetBatchLines, -1
 SetControlDelay -1
 Thread, interrupt, 0
-global version := 4.1
+global version := 4.11
 global iniFile := "wc3rpgLoaderData.ini"
 global CameraExe := "Camera\publish\Camera.exe"
 global KeyWaiting := False


### PR DESCRIPTION
Added Enter, Shift + Enter, and Numpad Enter to the list of hotkeys that toggles the inventory/quickcast hotkeys when chatting.
Also added Esc and left click for re-enabling the inventory/quickcast hotkeys when chatting is canceled.

Side note: the left click might be a bit problematic if the user clicks on the UI part of the screen. It will still re-enable the hotkey however it won't close the chat. I think it should be fine tho...